### PR TITLE
Fix gemfile lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,7 +127,15 @@ GEM
     cucumber-html-formatter (21.15.1)
       cucumber-messages (> 19, < 28)
     cucumber-messages (27.2.0)
+    cucumber-rails (4.0.0)
+      capybara (>= 3.25, < 4)
+      cucumber (>= 7, < 11)
+      railties (>= 6.1, < 9)
     cucumber-tag-expressions (8.0.0)
+    database_cleaner-active_record (2.2.2)
+      activerecord (>= 5.a)
+      database_cleaner-core (~> 2.0)
+    database_cleaner-core (2.0.1)
     date (3.5.0)
     debug (1.11.0)
       irb (~> 1.10)
@@ -139,6 +147,7 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.6.2)
+    docile (1.4.1)
     drb (2.2.3)
     erb (5.1.3)
     erubi (1.13.1)
@@ -303,6 +312,12 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.2)
+    simplecov_json_formatter (0.1.4)
     sprockets (4.2.2)
       concurrent-ruby (~> 1.0)
       logger
@@ -364,6 +379,8 @@ DEPENDENCIES
   bootsnap
   capybara
   cucumber
+  cucumber-rails
+  database_cleaner-active_record
   debug
   devise
   importmap-rails
@@ -374,6 +391,7 @@ DEPENDENCIES
   rails-controller-testing
   rspec-rails
   selenium-webdriver
+  simplecov
   sprockets-rails
   sqlite3 (>= 1.4)
   stimulus-rails


### PR DESCRIPTION
- Tried to deploy to Heroku, but I got an error that said "the dependencies in my gemfile changed, but the lockfile can't be updated." Couldn't push to heroku from github's main branch as a result.
- Fixed issue by unfreezing bundler by running 'bundle config frozen', then 'bundle install' to update the lockfile
- Am now able to deploy, but want to push to main first. Can you check to see if the code in main runs on your machine?