### PR TITLE
Fix Back button redirection and user event view access

### DIFF
--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -262,5 +262,5 @@
   </div>
 
   <br>
-  <div class="mb-4"><%= link_to "Back", request.referer || root_path, class: "btn btn-outline-primary" %></div>
+  <div class="mb-4"><%= link_to "Back", root_path, class: "btn btn-outline-primary" %></div>
 </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -120,8 +120,9 @@
         </td>
         <td>
           <div class="d-flex gap-2">
+            <% if event_user.status == 'joined'%>
             <%= link_to "View", event_path(event), class: "btn btn-sm btn-outline-primary" %>
-
+            <% end %>
               <% if event_user.status == 'invited' && @view_mode != 'past' %>
                 <%= button_to "Accept",
                               event_event_user_path(event, event_user, status: 'joined'),

--- a/app/views/user_gift_summary/show.html.erb
+++ b/app/views/user_gift_summary/show.html.erb
@@ -166,7 +166,7 @@
                 class: "btn btn-success" %>
   </div>
   <br>
-  <div class="mb-4"><%= link_to "Back", request.referer || root_path, class: "btn btn-outline-primary" %></div>
+  <div class="mb-4"><%= link_to "Back", @event, class: "btn btn-outline-primary" %></div>
 </div>
 
 


### PR DESCRIPTION
- Applied some minor redirection fixes to the back buttons so we don't get stuck in an endless loop trying to get back to the home page
- If a user hasn't joined the event, I took away the View event button. Currently, a user who has been invited to an event but hasn't joined it has the ability to visit the event page. As a result, they can start adding gifts for an event they haven't joined yet, which is undesirable behavior. Taking away the View button for users who haven't joined prevents this.